### PR TITLE
CSP blocking issue and user-facing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Discord server: [edpuzzle.hs.vc/discord.html](https://edpuzzle.hs.vc/discord.htm
   - [Demo](#demo)
   - [Features](#features)
   - [Limitations](#limitations)
+  - [Troubleshooting](#troubleshooting)
   - [Copyright Notice](#copyright-notice)
   - [Creating the Bookmarklet](#creating-the-bookmarklet)
   - [Using the Bookmarklet](#using-the-bookmarklet)
@@ -48,6 +49,24 @@ Note: This video was recorded with an older version of the script, so the GUI sh
 
 ## Limitations:
  - This doesn't currently work for most Edpuzzles that are embedded in a third party site. However, the script does work for Edpuzzles embeded in Canvas and Schoology.
+
+## Troubleshooting:
+
+### Script Blocked by Content Security Policy (CSP)
+If the script stops working and you see an error in the browser console mentioning **Content Security Policy** or **CSP**, this means Edpuzzle has added a CSP header that prevents the bookmarklet from loading external resources.
+
+**Fix:** Install the [Disable Content Security Policy](https://chromewebstore.google.com/detail/disable-content-security/ieelmcmcagommplceebfedjlakkhpden?hl=en) extension for Chrome (or any Chromium-based browser like Edge, Brave, or Opera).
+
+**Important:** Only enable this extension while using the Edpuzzle bookmarklet, and disable it again afterward. Disabling CSP globally can expose you to security risks on other websites. The extension has an on/off toggle in the Chrome toolbar for easy control.
+
+Steps:
+1. Install the extension from the link above.
+2. Click the extension icon in your toolbar to enable it.
+3. Reload the Edpuzzle assignment page.
+4. Run the bookmarklet as normal.
+5. Disable the extension again when you are done.
+
+**Note:** This extension is only available for Chromium-based browsers. Firefox users can try [Disable Content Security Policy](https://addons.mozilla.org/en-US/firefox/addon/disable-content-security-policy/) from the Firefox Add-ons store.
 
 ## Copyright Notice:
 ```
@@ -140,6 +159,7 @@ All other code has been written solely by me, [ading2210](https://github.com/adi
 Other contributors:
 - [@smatian](https://github.com/smatian) - Improved the popup CSS and auto answerer (#68)
 - [@simplyrohan](https://github.com/simplyrohan) - Major reorganization and fixes for Edpuzzle update + AI updates
+- [@Aaks-hatH](https://github.com/Aaks-hatH) - Identified and resolved a major Content Security Policy (CSP) blocking issue ([fix details](#troubleshooting))
 
 This project contains icons from the the [Iconoir](https://iconoir.com/) icon library. 
 

--- a/app/main.js
+++ b/app/main.js
@@ -603,6 +603,29 @@ async function init() {
     parse_questions();
   }
   catch (error) {
+    // Check for CSP-related errors and show a targeted fix message
+    const error_str = error + "";
+    const is_csp_error = (
+      error_str.toLowerCase().includes("content security policy") ||
+      error_str.toLowerCase().includes("csp") ||
+      error_str.toLowerCase().includes("refused to load") ||
+      error_str.toLowerCase().includes("violates the following content security policy")
+    );
+    if (is_csp_error) {
+      status_text.innerHTML = `
+        <b>Content Security Policy (CSP) is blocking this script.</b><br><br>
+        To fix this, install the 
+        <a href="https://chromewebstore.google.com/detail/disable-content-security/ieelmcmcagommplceebfedjlakkhpden?hl=en" 
+           target="_blank" 
+           style="color:#93c5fd;text-decoration:underline;">
+          Disable Content Security Policy
+        </a> 
+        Chrome extension, enable it, then reload this page and run the bookmarklet again.<br><br>
+        <span style="font-size:0.85em;opacity:0.7;">Remember to disable the extension again when you're done.</span>
+      `;
+      console.error("CSP error detected:", error);
+      return;
+    }
     console.error(error + "");
     console.error(error.stack);
     status_text.innerText = `An error has occurred. Please check the JS console for more details.\n\n${error+""}`;


### PR DESCRIPTION
## Summary
 
Edpuzzle's Content Security Policy now blocks the bookmarklet in some environments. This PR adds detection and user-facing guidance so users know what is happening and how to fix it.
 
## Changes
 
**app/main.js**
- Added CSP error detection in the top-level catch block
- If the error matches CSP keywords, the popup now shows a targeted message with a direct link to the Disable Content Security Policy Chrome extension
- Non-CSP errors fall through to the existing generic error message unchanged
 
**README.md**
- Added Troubleshooting section covering the CSP issue, fix steps, and a Firefox alternative
- Added Troubleshooting to the table of contents
- Credited [@Aaks-hatH](https://github.com/Aaks-hatH) in contributors for identifying and resolving the issue, with a link to the troubleshooting section
 
## Testing
 
Trigger a CSP error in the popup and confirm the new message appears. Trigger an unrelated error and confirm the generic fallback message still appears.